### PR TITLE
Add default wfc values, re-enable ViLTE and add provisioning patches

### DIFF
--- a/overlay/packages/apps/CarrierConfig/res/xml/vendor.xml
+++ b/overlay/packages/apps/CarrierConfig/res/xml/vendor.xml
@@ -57,9 +57,8 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.-->
 
         <!-- Enable SS over UT by default -->
         <boolean name="carrier_supports_ss_over_ut_bool" value="true" />
-    </carrier_config>
 
-    <!--
+        <!--
         Removed most custom CarrierConfigs to provide a single, universally functional one. We cannot
         be expected to make CarrierConfigs for all providers in the world, but we do want our phone
         to work with as many of them as possible. So, we keep Custom Modems and enable required provisioning,
@@ -67,24 +66,20 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.-->
         for carriers that do not need / offer this functionality, they will register a compatible
         phone inside IMS regardless, providing us with the possibility of setting the provisioning
         complete this way.
-    -->
-    
-    <carrier_config>
-        <!-- Make VoLTE and VoWiFi "available" or "enabled by platform". -->
-        <!-- Video Telephony currently not supported by ROM. EAB RCS not working?-->
+        -->
+        <!-- Make VoLTE, ViLTE and VoWiFi "available" or "enabled by platform". -->
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="true" />
-        <boolean name="carrier_vt_available_bool" value="false" />
+        <boolean name="carrier_vt_available_bool" value="true" />
         <boolean name="use_rcs_presence_bool" value="true" />
-        
         <!-- VoLTE and VoWiFi on by default, to allow IMS registration, needed for simulated provisioning. -->
         <boolean name="enhanced_4g_lte_on_by_default_bool" value="true" />
         <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
-	
+
         <!-- Require provisioning, so unavailable features are not used. -->
         <!-- Simulated provisioning where carrier does not provide any. -->
         <boolean name="carrier_volte_provisioning_required_bool" value="true" />
-	
+
         <!-- Downgrade when Video Telephony is unavailable. -->
         <boolean name="support_downgrade_vt_to_audio_bool" value="true" />
         <boolean name="allow_video_calling_fallback_bool" value="true" />
@@ -93,11 +88,125 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.-->
         <boolean name="vowifi_call_quality" value="true" />
         <boolean name="show_video_quality_ui" value="true" />
     </carrier_config>
-		
+
     <!--
         Remaining original CarrierConfigs start here
     -->
-	
+
+    <!-- Carrier-specific Cosmote GR -->
+    <carrier_config mcc="202" mnc="01">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+        <int name="carrier_default_wfc_ims_roaming_mode_int" value="1" />
+    </carrier_config>
+
+    <!-- Carrier-specific Swisscom CH -->
+    <carrier_config mcc="228" mnc="01">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+        <int name="carrier_default_wfc_ims_roaming_mode_int" value="1" />
+    </carrier_config>
+
+    <!-- Carrier-specific customized CH -->
+    <carrier_config mcc="228" mnc="02">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+    </carrier_config>
+
+    <!-- Carrier-specific T-Mobile CZ -->
+    <carrier_config mcc="230" mnc="01">
+        <int name="carrier_default_wfc_ims_roaming_mode_int" value="1" />
+    </carrier_config>
+
+    <!-- Carrier-specific Vodafone CZ -->
+    <carrier_config mcc="230" mnc="03" spn="Vodafone CZ">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+    </carrier_config>
+
+    <!-- Carrier-specific O2 Pay monthly UK -->
+    <carrier_config mcc="234" mnc="02">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+    </carrier_config>
+    <carrier_config mcc="234" mnc="10">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+    </carrier_config>
+    <carrier_config mcc="234" mnc="11">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+    </carrier_config>
+
+    <!-- Carrier-specific Vodafone UK -->
+    <carrier_config mcc="234" mnc="15">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+        <int name="carrier_default_wfc_ims_roaming_mode_int" value="1" />
+    </carrier_config>
+
+    <!-- Carrier-specific customized NOBA -->
+        <carrier_config mcc="238" mnc="02">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+    </carrier_config>
+    <carrier_config mcc="238" mnc="06">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+    </carrier_config>
+    <carrier_config mcc="240" mnc="01" spn="Telia">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+    </carrier_config>
+    <carrier_config mcc="240" mnc="01" spn="halebop">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+    </carrier_config>
+    <carrier_config mcc="240" mnc="02">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+    </carrier_config>
+    <carrier_config mcc="240" mnc="02" spn="3">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+    </carrier_config>
+    <carrier_config mcc="240" mnc="02" spn="hallon">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+    </carrier_config>
+    <!-- Carrier-specific customized UK -->
+    <carrier_config mcc="242" mnc="02">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+    </carrier_config>
+    <carrier_config mcc="242" mnc="05">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+    </carrier_config>
+
+    <!-- Carrier-specific T-Mobile PL -->
+    <carrier_config mcc="260" mnc="02">
+        <int name="carrier_default_wfc_ims_roaming_mode_int" value="1" />
+    </carrier_config>
+
+    <!-- Carrier-specific customized DE -->
+    <carrier_config mcc="262" mnc="01">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+    </carrier_config>
+
+    <!-- Carrier-specific Telekom.de DE -->
+    <carrier_config mcc="262" mnc="01" gid1="01">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+    </carrier_config>
+    <carrier_config mcc="262" mnc="01" gid1="02">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+    </carrier_config>
+    <carrier_config mcc="262" mnc="01" gid1="03">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+    </carrier_config>
+    <carrier_config mcc="262" mnc="01" gid1="99">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+    </carrier_config>
+    <carrier_config mcc="262" mnc="01" spn="congstar">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+    </carrier_config>
+    <carrier_config mcc="262" mnc="01" spn="congstar.de">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+    </carrier_config>
+
+    <!-- Carrier-specific customized TR -->
+    <carrier_config mcc="286" mnc="01">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+    </carrier_config>
+
+    <carrier_config mcc="286" mnc="02">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+        <int name="carrier_default_wfc_ims_roaming_mode_int" value="1" />
+    </carrier_config>
+
     <carrier_config mcc="405" mnc="840">
         <boolean name="video_call_use_ext" value="false" />
         <boolean name="use_custom_video_ui" value="true" />
@@ -120,7 +229,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.-->
         </string-array>
         <boolean name="config_retry_sms_over_ims" value="true"/>
         <boolean name="config_update_service_status" value="false"/>
-        <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
 
     <carrier_config mcc="405" mnc="854">
@@ -145,7 +253,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.-->
         </string-array>
         <boolean name="config_retry_sms_over_ims" value="true"/>
         <boolean name="config_update_service_status" value="false"/>
-        <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
 
     <carrier_config mcc="405" mnc="855">
@@ -170,7 +277,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.-->
         </string-array>
         <boolean name="config_retry_sms_over_ims" value="true"/>
         <boolean name="config_update_service_status" value="false"/>
-        <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
 
     <carrier_config mcc="405" mnc="856">
@@ -195,7 +301,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.-->
         </string-array>
         <boolean name="config_retry_sms_over_ims" value="true"/>
         <boolean name="config_update_service_status" value="false"/>
-        <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
 
     <carrier_config mcc="405" mnc="857">
@@ -220,7 +325,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.-->
         </string-array>
         <boolean name="config_retry_sms_over_ims" value="true"/>
         <boolean name="config_update_service_status" value="false"/>
-        <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
 
     <carrier_config mcc="405" mnc="858">
@@ -245,7 +349,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.-->
         </string-array>
         <boolean name="config_retry_sms_over_ims" value="true"/>
         <boolean name="config_update_service_status" value="false"/>
-        <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
 
     <carrier_config mcc="405" mnc="859">
@@ -270,7 +373,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.-->
         </string-array>
         <boolean name="config_retry_sms_over_ims" value="true"/>
         <boolean name="config_update_service_status" value="false"/>
-        <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
 
     <carrier_config mcc="405" mnc="860">
@@ -295,7 +397,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.-->
         </string-array>
         <boolean name="config_retry_sms_over_ims" value="true"/>
         <boolean name="config_update_service_status" value="false"/>
-        <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
 
     <carrier_config mcc="405" mnc="861">
@@ -320,7 +421,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.-->
         </string-array>
         <boolean name="config_retry_sms_over_ims" value="true"/>
         <boolean name="config_update_service_status" value="false"/>
-        <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
 
     <carrier_config mcc="405" mnc="862">
@@ -345,7 +445,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.-->
         </string-array>
         <boolean name="config_retry_sms_over_ims" value="true"/>
         <boolean name="config_update_service_status" value="false"/>
-        <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
 
     <carrier_config mcc="405" mnc="863">
@@ -370,7 +469,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.-->
         </string-array>
         <boolean name="config_retry_sms_over_ims" value="true"/>
         <boolean name="config_update_service_status" value="false"/>
-        <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
 
     <carrier_config mcc="405" mnc="864">
@@ -395,7 +493,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.-->
         </string-array>
         <boolean name="config_retry_sms_over_ims" value="true"/>
         <boolean name="config_update_service_status" value="false"/>
-        <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
 
     <carrier_config mcc="405" mnc="865">
@@ -420,7 +517,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.-->
         </string-array>
         <boolean name="config_retry_sms_over_ims" value="true"/>
         <boolean name="config_update_service_status" value="false"/>
-        <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
 
     <carrier_config mcc="405" mnc="866">
@@ -445,7 +541,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.-->
         </string-array>
         <boolean name="config_retry_sms_over_ims" value="true"/>
         <boolean name="config_update_service_status" value="false"/>
-        <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
 
     <carrier_config mcc="405" mnc="867">
@@ -470,7 +565,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.-->
         </string-array>
         <boolean name="config_retry_sms_over_ims" value="true"/>
         <boolean name="config_update_service_status" value="false"/>
-        <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
 
     <carrier_config mcc="405" mnc="868">
@@ -495,7 +589,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.-->
         </string-array>
         <boolean name="config_retry_sms_over_ims" value="true"/>
         <boolean name="config_update_service_status" value="false"/>
-        <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
 
     <carrier_config mcc="405" mnc="869">
@@ -520,7 +613,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.-->
         </string-array>
         <boolean name="config_retry_sms_over_ims" value="true"/>
         <boolean name="config_update_service_status" value="false"/>
-        <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
 
     <carrier_config mcc="405" mnc="870">
@@ -545,7 +637,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.-->
         </string-array>
         <boolean name="config_retry_sms_over_ims" value="true"/>
         <boolean name="config_update_service_status" value="false"/>
-        <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
 
     <carrier_config mcc="405" mnc="871">
@@ -570,7 +661,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.-->
         </string-array>
         <boolean name="config_retry_sms_over_ims" value="true"/>
         <boolean name="config_update_service_status" value="false"/>
-        <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
 
     <carrier_config mcc="405" mnc="872">
@@ -595,7 +685,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.-->
         </string-array>
         <boolean name="config_retry_sms_over_ims" value="true"/>
         <boolean name="config_update_service_status" value="false"/>
-        <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
 
     <carrier_config mcc="405" mnc="873">
@@ -620,7 +709,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.-->
         </string-array>
         <boolean name="config_retry_sms_over_ims" value="true"/>
         <boolean name="config_update_service_status" value="false"/>
-        <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
 
     <carrier_config mcc="405" mnc="874">
@@ -645,7 +733,22 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.-->
         </string-array>
         <boolean name="config_retry_sms_over_ims" value="true"/>
         <boolean name="config_update_service_status" value="false"/>
-        <int name="carrier_default_wfc_ims_mode_int" value="2" />
     </carrier_config>
 
+    <!-- Carrier-specific customized TW -->
+    <carrier_config mcc="466" mnc="01">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+    </carrier_config>
+            <carrier_config mcc="466" mnc="92">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+    </carrier_config>
+
+    <!-- Carrier-specific Vodacom ZA -->
+    <carrier_config mcc="655" mnc="01">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+    </carrier_config>
+    <!-- Carrier-specific Movistar AR -->
+    <carrier_config mcc="722" mnc="070">
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+    </carrier_config>
 </carrier_config_list>

--- a/patches/disable-provision-toggles.patch
+++ b/patches/disable-provision-toggles.patch
@@ -1,0 +1,46 @@
+# PWD: packages/apps/Settings
+From 907d5897ed90bf1e210c6c42bd958eac388e6c5d Mon Sep 17 00:00:00 2001
+From: antoniu200 <33966771+antoniu200@users.noreply.github.com>
+Date: Sun, 18 Feb 2024 00:23:33 +0200
+Subject: [PATCH] Always keep provision toggles to off: RadioInfo.java
+
+No matter if ROM is built as User, Userdebug or whatever else.
+---
+ src/com/android/settings/RadioInfo.java | 12 ++++--------
+ 1 file changed, 4 insertions(+), 8 deletions(-)
+
+diff --git a/src/com/android/settings/RadioInfo.java b/src/com/android/settings/RadioInfo.java
+index 249db58d335..e5843122a86 100644
+--- a/src/com/android/settings/RadioInfo.java
++++ b/src/com/android/settings/RadioInfo.java
+@@ -1540,26 +1540,22 @@ private void updateImsProvisionedState() {
+         imsVolteProvisionedSwitch.setOnCheckedChangeListener(null);
+         imsVolteProvisionedSwitch.setChecked(isImsVolteProvisioned());
+         imsVolteProvisionedSwitch.setOnCheckedChangeListener(mImsVolteCheckedChangeListener);
+-        imsVolteProvisionedSwitch.setEnabled(!Build.IS_USER
+-                && mImsManager.isVolteEnabledByPlatform(mPhone.getContext()));
++        imsVolteProvisionedSwitch.setEnabled(false);
+ 
+         imsVtProvisionedSwitch.setOnCheckedChangeListener(null);
+         imsVtProvisionedSwitch.setChecked(isImsVtProvisioned());
+         imsVtProvisionedSwitch.setOnCheckedChangeListener(mImsVtCheckedChangeListener);
+-        imsVtProvisionedSwitch.setEnabled(!Build.IS_USER
+-                && mImsManager.isVtEnabledByPlatform(mPhone.getContext()));
++        imsVtProvisionedSwitch.setEnabled(false);
+ 
+         imsWfcProvisionedSwitch.setOnCheckedChangeListener(null);
+         imsWfcProvisionedSwitch.setChecked(isImsWfcProvisioned());
+         imsWfcProvisionedSwitch.setOnCheckedChangeListener(mImsWfcCheckedChangeListener);
+-        imsWfcProvisionedSwitch.setEnabled(!Build.IS_USER
+-                && mImsManager.isWfcEnabledByPlatform(mPhone.getContext()));
++        imsWfcProvisionedSwitch.setEnabled(false);
+ 
+         eabProvisionedSwitch.setOnCheckedChangeListener(null);
+         eabProvisionedSwitch.setChecked(isEabProvisioned());
+         eabProvisionedSwitch.setOnCheckedChangeListener(mEabCheckedChangeListener);
+-        eabProvisionedSwitch.setEnabled(!Build.IS_USER
+-                && isEabEnabledByPlatform(mPhone.getContext()));
++        eabProvisionedSwitch.setEnabled(false);
+     }
+ 
+     OnClickListener mDnsCheckButtonHandler = new OnClickListener() {

--- a/patches/provision-carriers.patch
+++ b/patches/provision-carriers.patch
@@ -1,0 +1,64 @@
+# PWD: frameworks/opt/telephony
+From 959dcadfec2f7a44f8d884c28f9fa5321ddf6ee0 Mon Sep 17 00:00:00 2001
+From: antoniu200 <33966771+antoniu200@users.noreply.github.com>
+Date: Sun, 18 Feb 2024 00:29:33 +0200
+Subject: [PATCH] Correctly provision carriers that do not offer provisioning:
+ ImsPhoneCallTracker.java
+
+Otherwise, we end up either enabling more features than available, or none.
+
+Flamefire: Use isImsCapabilityAvailable and reuse imsManager
+---
+
+diff --git a/src/java/com/android/internal/telephony/imsphone/ImsPhoneCallTracker.java b/src/java/com/android/internal/telephony/imsphone/ImsPhoneCallTracker.java
+index 992d9aa8ea..e05a7da1f5 100644
+--- a/src/java/com/android/internal/telephony/imsphone/ImsPhoneCallTracker.java
++++ b/src/java/com/android/internal/telephony/imsphone/ImsPhoneCallTracker.java
+@@ -3661,22 +3661,38 @@ public class ImsPhoneCallTracker extends CallTracker implements ImsPullCall {
+         return (getImsRegistrationTech() == regTech) && mMmTelCapabilities.isCapable(capability);
+     }
+ 
++    private ImsManager getImsManager() {
++        return ImsManager.getInstance(mPhone.getContext(), mPhone.getPhoneId());
++    }
++
+     public boolean isVolteEnabled() {
+-        boolean isRadioTechLte = getImsRegistrationTech()
+-                == ImsRegistrationImplBase.REGISTRATION_TECH_LTE;
+-        return isRadioTechLte && mMmTelCapabilities.isCapable(
+-                MmTelFeature.MmTelCapabilities.CAPABILITY_TYPE_VOICE);
++        boolean isVolteEnabled = isImsCapabilityAvailable(MmTelFeature.MmTelCapabilities.CAPABILITY_TYPE_VOICE, ImsRegistrationImplBase.REGISTRATION_TECH_LTE);
++        if (isVolteEnabled) {
++            ImsManager imsManager = getImsManager();
++            if (!imsManager.isVolteProvisionedOnDevice()) // Not provisioned, but registered? Carrier probably needs no provisioning.
++                imsManager.setVolteProvisioned(true);
++        }
++        return isVolteEnabled;
+     }
+ 
+     public boolean isVowifiEnabled() {
+-        boolean isRadioTechIwlan = getImsRegistrationTech()
+-                == ImsRegistrationImplBase.REGISTRATION_TECH_IWLAN;
+-        return isRadioTechIwlan && mMmTelCapabilities.isCapable(
+-                MmTelFeature.MmTelCapabilities.CAPABILITY_TYPE_VOICE);
++        boolean isVowifiEnabled = isImsCapabilityAvailable(MmTelFeature.MmTelCapabilities.CAPABILITY_TYPE_VOICE, ImsRegistrationImplBase.REGISTRATION_TECH_IWLAN);
++        if (isVowifiEnabled) {
++            ImsManager imsManager = getImsManager();
++            if (!imsManager.isWfcProvisionedOnDevice()) // Not provisioned, but registered? Carrier probably needs no provisioning.
++                imsManager.setWfcProvisioned(true);
++        }
++        return isVowifiEnabled;
+     }
+ 
+     public boolean isVideoCallEnabled() {
+-        return mMmTelCapabilities.isCapable(MmTelFeature.MmTelCapabilities.CAPABILITY_TYPE_VIDEO);
++        boolean isVideoCallEnabled = mMmTelCapabilities.isCapable(MmTelFeature.MmTelCapabilities.CAPABILITY_TYPE_VIDEO);
++        if (isVideoCallEnabled) {
++            ImsManager imsManager = getImsManager();
++            if (!imsManager.isVtProvisionedOnDevice()) // Not provisioned, but registered? Carrier probably needs no provisioning.
++                imsManager.setVtProvisioned(true);
++        }
++        return isVideoCallEnabled;
+     }
+ 
+     @Override


### PR DESCRIPTION
I double checked your changes in https://github.com/Flamefire/android_device_sony_lilac/pull/23 and found the following improvements:

- Don't add a second top-level/unrestricted `<carrier_config>` (not 100% sure the parser used by Android will combine both and not "forget" one)
- ViLTE is only disabled for LOS 19.1 as you noticed in https://github.com/Flamefire/android_device_sony_yoshino-common/pull/40#discussion_r1527563474 so we can enable it by default too
- `carrier_default_wfc_ims_mode_int` & `carrier_default_wfc_ims_roaming_mode_int` default to "2" (see `frameworks/base/telephony/java/android/telephony/CarrierConfigManager.java`) so remove the entries setting it to that default and keep the others
- Remove some whitespace at the end of lines

I also added your changes from https://github.com/antoniu200/android_frameworks_opt_telephony/commit/959dcadfec2f7a44f8d884c28f9fa5321ddf6ee0 (with minor changes) & https://github.com/antoniu200/android_packages_apps_Settings/commit/907d5897ed90bf1e210c6c42bd958eac388e6c5d as patch files that can be applied with `applyPatches`

With this I think the PR is ready, so opening this as a PR to your branch such that the actual change commit is still yours.