### PR TITLE
enable avb with lilac lineageos build

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -46,3 +46,13 @@ TARGET_SCREEN_DENSITY := 300
 # Add device-specific ones
 TARGET_SYSTEM_PROP += $(DEVICE_PATH)/system.prop
 TARGET_VENDOR_PROP += $(DEVICE_PATH)/vendor.prop
+
+ifneq ($(wildcard build/target/product/security/avb.pem),)
+BOARD_AVB_ENABLE := true
+BOARD_AVB_ALGORITHM := SHA256_RSA4096
+BOARD_AVB_KEY_PATH := build/target/product/security/avb.pem
+BOARD_AVB_RECOVERY_ALGORITHM := SHA256_RSA4096
+BOARD_AVB_RECOVERY_KEY_PATH := build/target/product/security/avb.pem
+BOARD_AVB_RECOVERY_ROLLBACK_INDEX := 1
+BOARD_AVB_RECOVERY_ROLLBACK_INDEX_LOCATION := 1
+endif


### PR DESCRIPTION
this will create vbmeta partition image with 'mka target-files-package' as part of the target-files-*-lilac-signed.zip archive: IMAGES/vbmeta.img

Change-Id: I293e16298a81e3ee5e8c6db5eb73ca4b6f2da171